### PR TITLE
Remove redundant Varna condition

### DIFF
--- a/src/components/home/PropertyCalculator.tsx
+++ b/src/components/home/PropertyCalculator.tsx
@@ -133,8 +133,6 @@ if (city === "Plovdiv") {
   rateShortTerm = getSofiaShortTermRate(neighborhood, bedrooms);
 } else if (city === "Varna") {
   rateShortTerm = getVarnaShortTermRate(neighborhood, bedrooms);
-} else if (city === "Varna") {
-  rateShortTerm = getVarnaShortTermRate(neighborhood, bedrooms);
 } else {
   rateShortTerm = [36, 48, 60][parseInt(bedrooms)] * 0.75;
 }


### PR DESCRIPTION
## Summary
- clean up `PropertyCalculator` logic by removing duplicate `city === "Varna"` branch

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683ff81772208330ac47d0e17b0d35a6